### PR TITLE
Adding framework for past events

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,19 +20,28 @@ layout: default
 
 and we'll be involved in PyCon Namibia 2016 in February, while <a href="http://pyconuk.org">PyCon UK</a> will come to Cardiff in September 2016.</p>
 
+
   <h1 class="page-heading">Forthcoming events</h1>
+
+  {% capture current_date %} {{ 'now' | date: '%s'}} {% endcapture %}
 
   <ul class="post-list">
     {% for post in site.events %}
-      <li>
-      <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }} {{post.time}}</span>
-        {% if post.venue %}
-          at <span class="post-meta">{{ post.venue }}</span>
-        {% endif %}
-        <h2>
-          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-        </h2>
-      </li>
+
+      {% capture post_date %} {{ post.date | date: '%s'}} {% endcapture %}
+
+      {% if post_date >= current_date %}
+          <li>
+          <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }} {{post.time}}</span>
+            {% if post.venue %}
+              at <span class="post-meta">{{ post.venue }}</span>
+            {% endif %}
+            <h2>
+              <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+            </h2>
+          </li>
+      {% endif %}
+
     {% endfor %}
   </ul>
 

--- a/past.html
+++ b/past.html
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Past events
+permalink: /past/
+order: 50
+---
+
+<div class="home">
+  <h1 class="page-heading">Past events</h1>
+
+  {% capture current_date %} {{ 'now' | date: '%s'}} {% endcapture %}
+
+  <ul class="post-list">
+    {% for post in site.events %}
+
+      {% capture post_date %} {{ post.date | date: '%s'}} {% endcapture %}
+
+      {% if post_date < current_date %}
+          <li>
+          <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }} {{post.time}}</span>
+            <h2>
+              <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+            </h2>
+          </li>
+      {% endif %}
+
+    {% endfor %}
+  </ul>
+
+</div>


### PR DESCRIPTION
This is a static site so a build needs to be run (the dates are read once and not dynamically).

For example if and when speakers add links to their talks they will
automatically move to the past events page.