### PR TITLE
Broken link fix

### DIFF
--- a/_events/2016-03-15.md
+++ b/_events/2016-03-15.md
@@ -18,4 +18,4 @@ What can Github and Meetup.com tell us about the UK's digital tech clusters? In 
 
 # Robert Dragan - The Learnium Tech Stack
 
-[Learnium] (https://learnium.com) is a Cardiff based company that has built a social learning network on top of Python and Django. Robert is the CEO of the company and will share his experience with Python and a bunch of other tool and frameworks used at Learnium.
+[Learnium](https://learnium.com) is a Cardiff based company that has built a social learning network on top of Python and Django. Robert is the CEO of the company and will share his experience with Python and a bunch of other tool and frameworks used at Learnium.


### PR DESCRIPTION
The extra space was breaking the link on http://www.pydiff.wales/events/2016-03-15.html but not in the GitHub preview