### PR TITLE
Updated events list title on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
 
     </section>
 
-  <h1 class="page-heading">Forthcoming events</h1>
+  <h1 class="page-heading">Recent and future events</h1>
 
   {% capture current_date %} {{ 'now' | date: '%s'}} {% endcapture %}
 


### PR DESCRIPTION
I have changed the title for the events list on the homepage as I noticed that the most recent event will stay as a 'future event' until a the next a new pr is pulled in allowing the code to be re run. As you can see in the pic below, Alex's talk on Blender and Ciw is incorrectly classed as a future event

![eventslist](https://cloud.githubusercontent.com/assets/8998661/20056437/03327ac6-a4de-11e6-99df-3acc8f63c91b.png)