### PR TITLE
Add May 2017 event info.

### DIFF
--- a/_events/2017-05-16.md
+++ b/_events/2017-05-16.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "A Production Python Stack / Lazy Sequences working hard"
+when:   2017-05-16
+time:   "19:00"
+venue:  "T/0.31, School of Computer Science & Informatics, Cardiff University"
+---
+
+# [Carl Cresswell](https://twitter.com/carl_cresswell): A Production Python Stack.
+
+We recently migrated to a Python stack to power our CNLP (Clinical Natural Language Processing) application portfolio.  Here we present a quick overview of our software stack and some of the lessons we learned in putting Python to work in production applications.
+
+
+# [Thomas Guest](https://twitter.com/thomasguest): Lazy Sequences working hard
+
+Python has no problem handling large and even infinite streams of data. Just write lazy programs -- code which defers data access until the last minute. This talk examines Python's language and library support for such delaying tactics. There will be live coding, and we'll draw parallels with similar features in other languages, in particular the Unix shell.
+
+
+# Location
+
+This month's venue is T/0.31 in the School of Computer Science & Informatics. Enter the complex through the main gates and follow the awesome signs!
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2484.5563658121855!2d-3.1726044842308547!3d51.4846569796314!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x486e1cb8742c46f5%3A0xc620b871e5d19cac!2sTrevithick+Bldg%2C+Cardiff+CF24!5e0!3m2!1sen!2suk!4v1456917752266" width="600" height="450" frameborder="0" style="border:0" allowfullscreen>&nbsp;</iframe>


### PR DESCRIPTION
Add event information for talks by Clinithink scheduled for May 2017